### PR TITLE
composer: add PHP dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
             "Tests\\": "tests/"
         }
     },
-    "require": {},
+    "require": {
+        "php": "^5.4|^7.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"
     }


### PR DESCRIPTION
It looks like PHP 5.4 is the minimum now
